### PR TITLE
Rewritten the configuration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.deuser
-Config.ini
+Config.cfg
 @EnableMobDebug.lua

--- a/Classes/PlayerState.lua
+++ b/Classes/PlayerState.lua
@@ -160,7 +160,7 @@ local function SetPos(a_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_Set
 	end
 	
 	-- Check if a wand is used:
-	if (a_Player:GetEquippedItem().m_ItemType ~= Wand) then
+	if (a_Player:GetEquippedItem().m_ItemType ~= g_Config.WandItem) then
 		return false
 	end
 	

--- a/Commands/Brush.lua
+++ b/Commands/Brush.lua
@@ -79,6 +79,12 @@ function HandleSphereBrush(a_Split, a_Player)
 		return true
 	end
 	
+	-- The radius is too large
+	if (Radius > g_Config.Limits.MaxBrushRadius) then
+		a_Player:SendMessage(cChatColor.Rose .. "Maximum brush radius: " .. g_Config.Limits.MaxBrushRadius)
+		return true
+	end
+	
 	-- The player state is used to get the player's mask, and to bind the tool
 	local State = GetPlayerState(a_Player)
 	
@@ -100,9 +106,8 @@ function HandleSphereBrush(a_Split, a_Player)
 		CreateSphereInCuboid(a_Player, AffectedArea, BlockTable, Hollow, Mask)
 		return true
 	end
-
-	local Succes, error = State.ToolRegistrator:BindTool(a_Player:GetEquippedItem().m_ItemType, BrushHandler)
 	
+	local Succes, error = State.ToolRegistrator:BindRightClickTool(a_Player:GetEquippedItem().m_ItemType, BrushHandler, "brush")
 	if (not Succes) then
 		a_Player:SendMessage(cChatColor.Rose .. error)
 		return true
@@ -143,6 +148,12 @@ function HandleCylinderBrush(a_Split, a_Player)
 		a_Player:SendMessage(cChatColor.Rose .. "Cannot convert radius \"" .. a_Split[4] .. "\" to a number.")
 		return true
 	end
+	
+	-- The radius is too large
+	if (Radius > g_Config.Limits.MaxBrushRadius) then
+		a_Player:SendMessage(cChatColor.Rose .. "Maximum brush radius: " .. g_Config.Limits.MaxBrushRadius)
+		return true
+	end
 
 	-- Convert the height param.
 	local Height = tonumber(a_Split[5])
@@ -176,8 +187,7 @@ function HandleCylinderBrush(a_Split, a_Player)
 		return true
 	end
 
-	local Succes, error = State.ToolRegistrator:BindTool(a_Player:GetEquippedItem().m_ItemType, BrushHandler)
-	
+	local Succes, error = State.ToolRegistrator:BindRightClickTool(a_Player:GetEquippedItem().m_ItemType, BrushHandler, "brush")
 	if (not Succes) then
 		a_Player:SendMessage(cChatColor.Rose .. error)
 		return true

--- a/Commands/Entities.lua
+++ b/Commands/Entities.lua
@@ -79,12 +79,17 @@ function HandleButcherCommand(a_Split, a_Player)
 	
 	local Radius;
 	if (a_Split[2] == nil) then -- if the player did not give a radius then the radius is the normal radius
-		Radius = ButcherRadius
+		Radius = g_Config.Defaults.ButcherRadius
 	elseif (tonumber(a_Split[2]) == nil) then -- if the player gave a string as radius then stop
 		a_Player:SendMessage(cChatColor.Rose .. 'Number expected; string "' .. Split[2] .. '" given')
 		return true
 	else -- the radius is set to the given radius
 		Radius = tonumber(a_Split[2])
+	end
+	
+	if ((g_Config.Limits.ButcherRadius > 0) and (Radius > g_Config.Limits.ButcherRadius)) then
+		a_Player:SendMessage(cChatColor.Rose .. 'Maximum butcher radius exceeded.')
+		return true
 	end
 	
 	-- If this is true then the mob will be destroyed regardless of how far he is from the player.

--- a/Commands/Special.lua
+++ b/Commands/Special.lua
@@ -79,7 +79,7 @@ end
 function HandleWandCommand(Split, Player)
 	-- //wand
 	
-	Item = cItem(Wand) -- create the cItem object
+	local Item = cItem(g_Config.WandItem) -- create the cItem object
 	if (Player:GetInventory():AddItem(Item)) then -- check if the player got the item
 		Player:SendMessage(cChatColor.Green .. "You have received the wand.")
 	else

--- a/Config.lua
+++ b/Config.lua
@@ -1,0 +1,123 @@
+
+-- Config.lua
+
+-- Contains the functions to initialize and write the configuration file.
+
+
+
+
+
+g_Config = {}
+
+
+
+
+
+local g_ConfigDefault =
+[[
+WandItem = 271,
+Limits =
+{
+	ButcherRadius = -1,
+	MaxBrushRadius = 5,
+},
+
+Defaults =
+{
+	ButcherRadius = 20,
+},
+
+NavigationWand =
+{
+	Item = 345,
+	MaxDistance = 120,
+	TeleportNoHit = true,
+},
+]]
+
+
+
+
+
+-- Writes the default configuration to a_Path
+local function WriteDefaultConfiguration(a_Path)
+	LOGWARNING("[WorldEdit] Default configuration written to \"" .. a_Path .. "\"")
+	local File = io.open(a_Path, "w")
+	File:write(g_ConfigDefault)
+	File:close()
+end
+
+
+
+
+
+-- Returns the default configuration table. This can be directly used in g_Config
+local function GetDefaultConfigurationTable()
+	return loadstring("return {" .. g_ConfigDefault .. "}")()
+end
+
+
+
+
+
+-- Sets g_Config to the default configuration
+local function LoadDefaultConfiguration()
+	LOGWARNING("[WorldEdit] The default configuration will be used.")
+	g_Config = GetDefaultConfigurationTable()
+end
+
+
+
+
+
+-- Finds from an error message where the error occurred.
+local function FindErrorPosition(a_ErrorMessage)
+	local ErrorPosition = a_ErrorMessage:match(":(.-):") or 0
+	return ErrorPosition
+end
+
+
+
+
+
+-- Loads the configuration from the given path. If it doesn't exist, or if there is an error in the config file it will load the defaults.
+function InitializeConfiguration(a_Path)
+	local ConfigContent = cFile:ReadWholeFile(a_Path)
+	
+	-- The configuration file doesn't exist or is empty. Write and load the default value
+	if (ConfigContent == "") then
+		WriteDefaultConfiguration(a_Path)
+		LoadDefaultConfiguration()
+		return
+	end
+	
+	-- Load the content of the config file. Place brackets around it to make the whole thing a table.
+	-- Also, return the table when executed
+	local ConfigLoader, Error = loadstring("return {" .. ConfigContent .. "}")
+	if (not ConfigLoader) then
+		local ErrorPosition = FindErrorPosition(Error)
+		LOGWARNING("[WorldEdit] Error in the configuration file near line " .. ErrorPosition)
+		LoadDefaultConfiguration()
+		return
+	end
+	
+	-- Execute the loader. It returns true + the configuration if it executed properly. Else it returns false with the error message.
+	local Succes, Result = pcall(ConfigLoader)
+	if (not Succes) then
+		local ErrorPosition = FindErrorPosition(Result)
+		LOGWARNING("[WorldEdit] Error in the configuration file at line " .. ErrorPosition)
+		LoadDefaultConfiguration()
+		return
+	end
+	
+	-- Merge the configuration with the default configuration. 
+	-- When the admin missed something in the configuration it will be set to the default value.
+	local DefaultConfig = GetDefaultConfigurationTable()
+	table.merge(Result, DefaultConfig)
+	
+	-- Set the g_Config table.
+	g_Config = Result
+end
+
+
+

--- a/Config.lua
+++ b/Config.lua
@@ -15,7 +15,7 @@ g_Config = {}
 
 local g_ConfigDefault =
 [[
-WandItem = 271,
+WandItem = woodenaxe,
 Limits =
 {
 	ButcherRadius = -1,
@@ -29,7 +29,7 @@ Defaults =
 
 NavigationWand =
 {
-	Item = 345,
+	Item = compass,
 	MaxDistance = 120,
 	TeleportNoHit = true,
 },
@@ -100,6 +100,17 @@ function InitializeConfiguration(a_Path)
 		LoadDefaultConfiguration()
 		return
 	end
+	
+	-- Create an environment for the loader where the admin can use item names directly without quotes.
+	local LoaderEnv = {}
+	for Key, Value in pairs(_G) do
+		if (Key:match("E_.*")) then
+			LoaderEnv[ItemTypeToString(Value)] = Value
+		end
+	end
+	
+	-- Apply the environment to the configloader.
+	setfenv(ConfigLoader, LoaderEnv)
 	
 	-- Execute the loader. It returns true + the configuration if it executed properly. Else it returns false with the error message.
 	local Succes, Result = pcall(ConfigLoader)

--- a/hooks.lua
+++ b/hooks.lua
@@ -37,11 +37,18 @@ function RightClickCompassHook(Player, BlockX, BlockY, BlockZ, BlockFace, Cursor
 	if BlockFace ~= BLOCK_FACE_NONE then
 		return false
 	end
-
-	-- Check if the equipped item is a compass.
-	if (Player:GetEquippedItem().m_ItemType == E_ITEM_COMPASS) and Player:HasPermission("worldedit.navigation.thru.tool") then
-		RightClickCompass(Player, Player:GetWorld())
+	
+	-- The player can't use the navigation tool because he doesn't have permission use it.
+	if (not Player:HasPermission("worldedit.navigation.thru.tool")) then
+		return false
 	end
+	
+	-- Check if the equipped item is a compass.
+	if (Player:GetEquippedItem().m_ItemType ~= g_Config.NavigationWand.Item) then
+		return false
+	end
+	
+	RightClickCompass(Player, Player:GetWorld())
 end
 
 
@@ -59,7 +66,7 @@ function LeftClickCompassHook(Player, BlockX, BlockY, BlockZ, BlockFace, Status)
 		return false
 	end
 	
-	if (Player:GetEquippedItem().m_ItemType ~= E_ITEM_COMPASS) then
+	if (Player:GetEquippedItem().m_ItemType ~= g_Config.NavigationWand.Item) then
 		return false
 	end
 	

--- a/hooks.lua
+++ b/hooks.lua
@@ -57,22 +57,19 @@ end
 ---------------------------------------------------
 -----------------LeftClickCompass------------------
 ---------------------------------------------------
-function LeftClickCompassHook(Player, BlockX, BlockY, BlockZ, BlockFace, Status)
-	if Status ~= 0 then
+function LeftClickCompassHook(a_Player, BlockX, BlockY, BlockZ, BlockFace, Status)
+	if (Status ~= 0) then
 		return false
 	end
 	
-	if (not Player:HasPermission("worldedit.navigation.jumpto.tool")) then
+	if (not a_Player:HasPermission("worldedit.navigation.jumpto.tool")) then
 		return false
 	end
 	
-	if (Player:GetEquippedItem().m_ItemType ~= g_Config.NavigationWand.Item) then
+	if (a_Player:GetEquippedItem().m_ItemType ~= g_Config.NavigationWand.Item) then
 		return false
 	end
 	
-	if (LeftClickCompassUsed[Player:GetName()]) then
-		return false
-	end
 	return true
 end
 
@@ -80,38 +77,20 @@ end
 ----------------------------------------------------
 -----------------ONPLAYERANIMATION------------------
 ----------------------------------------------------
-function OnPlayerAnimation(Player, Animation)
-	if Animation ~= 1 then
+function OnPlayerAnimation(a_Player, a_Animation)
+	if (a_Animation ~= 0) then
 		return false
 	end
 	
-	local PlayerName = Player:GetName()
-	
-	if (not LeftClickCompassUsed[PlayerName]) and (LeftClickCompassUsed[PlayerName] ~= nil) then
-		LeftClickCompassUsed[PlayerName] = true
+	if (a_Player:GetEquippedItem().m_ItemType ~= g_Config.NavigationWand.Item) then
 		return false
 	end
 	
-	if Player:GetEquippedItem().m_ItemType ~= E_ITEM_COMPASS then
+	if (not a_Player:HasPermission("worldedit.navigation.jumpto.tool")) then
 		return false
 	end
 	
-	if (not Player:HasPermission("worldedit.navigation.jumpto.tool")) then
-		return false
-	end
-	
-	local World = Player:GetWorld()
-	local PlayerID = Player:GetUniqueID()
-	LeftClickCompassUsed[PlayerName] = false
-	World:ScheduleTask(1, function(World)
-		World:DoWithEntityByID(PlayerID, function(Player)
-			if not LeftClickCompass(Player, Player:GetWorld()) then
-				Player:SendMessage(cChatColor.Rose .. "No blocks in sight (or too far)!")
-			end
-			LeftClickCompassUsed[PlayerName] = true
-		end)
-	end)
-				
+	LeftClickCompass(a_Player, a_Player:GetWorld())
 	return true
 end
 

--- a/main.lua
+++ b/main.lua
@@ -70,10 +70,10 @@ function Initialize(a_Plugin)
 	PLUGIN:SetName(g_PluginInfo.Name)
 	PLUGIN:SetVersion(g_PluginInfo.Version)
 		
-	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_RIGHT_CLICK,    RightClickCompassHook);
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_RIGHT_CLICK,    RightClickToolsHook);
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_LEFT_CLICK,     LeftClickToolsHook);
 	
+	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_RIGHT_CLICK,    RightClickCompassHook);
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_LEFT_CLICK,     LeftClickCompassHook);
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_ANIMATION,      OnPlayerAnimation);
 	
@@ -81,7 +81,7 @@ function Initialize(a_Plugin)
 	RegisterPluginInfoCommands();
 	
 	InitializeTables() -- create all the tables
-	LoadSettings(a_Plugin:GetLocalFolder() .. "/Config.ini") -- load all the settings
+	InitializeConfiguration(a_Plugin:GetLocalFolder() .. "/config.cfg")
 	
 	cFile:CreateFolder("schematics")
 	


### PR DESCRIPTION
No longer multiple variables that contain the config, but one single g_Config table that contains everything

I didn't implement a string-to-block/itemtype mechanism, because it could also be something other then a blocktype. Another solution to this is to give the loader a different global variable. Where we simply say
`_G[ItemTypeToString(ItemType)] = ItemType`

Any thoughts?